### PR TITLE
Bluetooth: Host: Don't start scanner bt_conn_le_create

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2675,6 +2675,7 @@ int bt_conn_le_create(const bt_addr_le_t *peer,
 
 #if defined(CONFIG_BT_SMP)
 	if (IS_ENABLED(CONFIG_BT_PRIVACY) &&
+	    (bt_dev.le.rl_entries > 0) &&
 	    (!bt_dev.le.rl_size || bt_dev.le.rl_entries > bt_dev.le.rl_size)) {
 		bt_conn_set_state(conn, BT_CONN_CONNECTING_SCAN);
 


### PR DESCRIPTION
Starting the pasive scanner so host can resolve addresses
shouldn't be nessesary when the resolving list is empty.

Signed-off-by: Martin Tverdal <martin.tverdal@nordicsemi.no>